### PR TITLE
Create T1562.009.yaml file for Atomic - "Impair Defenses: Safe Mode B…

### DIFF
--- a/atomics/T1562.009/T1562.009.yaml
+++ b/atomics/T1562.009/T1562.009.yaml
@@ -1,0 +1,13 @@
+attack_technique: T1562.009
+display_name: 'Impair Defenses: Safe Boot Mode'
+atomic_tests:
+- name: Safe Mode Boot 
+  description: Allows adversaries to abuse safe mode to disable endpoint defenses that may not start with limited boot
+  supported_platforms:
+  - windows
+  dependencies: 
+  executor:
+    command: bcdedit /set safeboot network
+    cleanup_command: bcdedit /deletevalue {current} safeboot
+    name: command_prompt
+    elevation_required: true


### PR DESCRIPTION
…oot""

**Details**: 
Allows adversaries to abuse safe mode to disable endpoint defenses that may not start with limited boot. This is achieved by modifying Boot Configuration Data (BCD) stores, which are files that manage boot application settings using the "bcdedit /set safeboot network" command and requires Elevated privileges

**Testing**
Testing was successfully carried out on Win 10 x64.  Cleanup commands "bcdedit /deletevalue {current} safeboot" was used to restore boot to normal

**Associated Issues**
None.

**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->